### PR TITLE
fix: make component compatible with near.social

### DIFF
--- a/src/Stake.jsx
+++ b/src/Stake.jsx
@@ -212,43 +212,6 @@ const YouWillReceive = styled.div`
     margin-top: 16px;
 `;
 
-const NEARInput = ({ value, onChange, onClickMax }) => {
-  return (
-    <NEARInputContainer>
-      <LogoWithText>
-        <img
-          src={`https://ipfs.near.social/ipfs/bafkreid5xjykpqdvinmj432ldrkbjisrp3m4n25n4xefd32eml674ypqly`}
-          width={26}
-          height={26}
-          alt="NEAR Icon"
-        />
-        <NEARTexture>NEAR</NEARTexture>
-      </LogoWithText>
-      <input
-        style={{
-          "text-align": "right",
-          width: "100%",
-          background: "transparent",
-          border: "0",
-          "font-size": "16px",
-          "font-weight": "bold",
-          color: state.inputError ? "#ec6868" : "white",
-          outline: "none",
-          "box-shadow": "none",
-          "margin-right": "16px",
-
-          "-webkit-appearance": "none",
-          "-moz-appearance": "textfield",
-        }}
-        placeholder="NEAR amount to stake"
-        value={value}
-        onChange={onChange}
-      />
-      <MaxTexture onClick={onClickMax}>MAX</MaxTexture>
-    </NEARInputContainer>
-  );
-};
-
 return (
   <Main>
     <a href="https://linearprotocol.org/" target="_blank">


### PR DESCRIPTION
### Issue

Fixed the compatibility issue with https://near.social as reported by Jordan

![image](https://user-images.githubusercontent.com/95207870/231635301-07407ac5-1fab-4b22-9dc3-84d027e443de.png)

### Analysis

It fails on https://near.social/ because the component rendering engine of its frontend is not the latest. Check the commit here: https://github.com/NearSocial/VM/commit/9e8b98c9fccf75566c36ee3542406f27eef48884

- Only styled component is supported in the current version;
- We implemented several functional components which are not supported yet on https://near.social, but working well on https://alpha.near.org

### Fixing

Make all functional components inlined: `NEARIcon`, `NEARInputComp`, `NEARInput`, `BrandImage`

### Testing

Copy [`Stake.jsx`](https://github.com/linear-protocol/linear-bos-components/blob/595e75a2adaafd5a94de7d3c3ca60e36580d054f/src/Stake.jsx) into https://near.social/edit#/edit and render the component. 



