### PR TITLE
fix: comma separator for received amount

### DIFF
--- a/src/LiNEAR/Stake.jsx
+++ b/src/LiNEAR/Stake.jsx
@@ -25,7 +25,12 @@ function isValid(a) {
 }
 
 function formatAmount(a) {
-  return isValid(a) ? Number(a).toLocaleString() : a;
+  return isValid(a)
+    ? Number(a).toLocaleString(null, {
+        minimumFractionDigits: 5,
+        maximumFractionDigits: 5,
+      })
+    : a;
 }
 
 /** common lib end */

--- a/src/LiNEAR/Stake.jsx
+++ b/src/LiNEAR/Stake.jsx
@@ -26,7 +26,7 @@ function isValid(a) {
 
 function formatAmount(a) {
   return isValid(a)
-    ? Number(a).toLocaleString(null, {
+    ? Number(a).toLocaleString(undefined, {
         minimumFractionDigits: 5,
         maximumFractionDigits: 5,
       })

--- a/src/LiNEAR/Stake.jsx
+++ b/src/LiNEAR/Stake.jsx
@@ -24,6 +24,10 @@ function isValid(a) {
   return true;
 }
 
+function formatAmount(a) {
+  return isValid(a) ? Number(a).toLocaleString() : a;
+}
+
 /** common lib end */
 function getNearBalance(accountId) {
   const account = fetch(config.nodeUrl, {
@@ -176,11 +180,12 @@ const linearPrice = Big(
   Near.view(config.contractId, "ft_price", `{}`) ?? "0"
 ).div(Big(10).pow(24));
 
-const youWillReceive = (
+const receivedLinear = (
   linearPrice.lte(0)
     ? Big(0)
     : Big(isValid(state.inputValue) ? state.inputValue : 0).div(linearPrice)
 ).toFixed(5, BIG_ROUND_DOWN);
+const formattedReceivedLinear = formatAmount(receivedLinear);
 
 const StakeFormWrapper = styled.div`
   width: 100%;
@@ -216,7 +221,7 @@ return (
     />
     <Widget
       src={`${config.ownerId}/widget/LiNEAR.Message.YouWillReceive`}
-      props={{ text: `${youWillReceive} LiNEAR` }}
+      props={{ text: `${formattedReceivedLinear} LiNEAR` }}
     />
   </StakeFormWrapper>
 );

--- a/src/LiNEAR/Unstake.jsx
+++ b/src/LiNEAR/Unstake.jsx
@@ -35,7 +35,7 @@ function isValid(a) {
 
 function formatAmount(a) {
   return isValid(a)
-    ? Number(a).toLocaleString(null, {
+    ? Number(a).toLocaleString(undefined, {
         minimumFractionDigits: 5,
         maximumFractionDigits: 5,
       })

--- a/src/LiNEAR/Unstake.jsx
+++ b/src/LiNEAR/Unstake.jsx
@@ -34,7 +34,12 @@ function isValid(a) {
 }
 
 function formatAmount(a) {
-  return isValid(a) ? Number(a).toLocaleString() : a;
+  return isValid(a)
+    ? Number(a).toLocaleString(null, {
+        minimumFractionDigits: 5,
+        maximumFractionDigits: 5,
+      })
+    : a;
 }
 
 /** common lib end */

--- a/src/LiNEAR/Unstake.jsx
+++ b/src/LiNEAR/Unstake.jsx
@@ -33,6 +33,10 @@ function isValid(a) {
   return true;
 }
 
+function formatAmount(a) {
+  return isValid(a) ? Number(a).toLocaleString() : a;
+}
+
 /** common lib end */
 function getLinearBalance(accountId) {
   const linearBalanceRaw = Near.view(config.contractId, "ft_balance_of", {
@@ -82,6 +86,13 @@ function getReceivedInstantUnstakeNear() {
 
 const receivedDelayedUnstakeNear = getReceivedDelayedUnstakeNear();
 const receivedInstantUnstakeNear = getReceivedInstantUnstakeNear();
+const formattedReceivedDelayedUnstakeNear = formatAmount(
+  receivedDelayedUnstakeNear
+);
+const formattedReceivedInstantUnstakeNear = formatAmount(
+  receivedInstantUnstakeNear
+);
+
 const UNSTAKE_DIFF_ERROR_RATIO = 0.05;
 const IMPACT_TOO_HIGH_ERROR = "Price impact high. Unstake less or try later";
 const validReceivedUnstakeAmount =
@@ -459,7 +470,9 @@ return (
             }}
           />
         </UnstakeTabTitle>
-        <EstimateGetValue>{receivedInstantUnstakeNear} NEAR</EstimateGetValue>
+        <EstimateGetValue>
+          {formattedReceivedInstantUnstakeNear} NEAR
+        </EstimateGetValue>
         <UnstakeFee>Unstake fee: 0.05%</UnstakeFee>
       </UnstakeTab>
       <UnstakeTab
@@ -467,7 +480,9 @@ return (
         onClick={() => State.update({ unstakeType: "delayed" })}
       >
         <UnstakeTabTitle>DELAYED UNSTAKE ~2 DAYS</UnstakeTabTitle>
-        <EstimateGetValue>{receivedDelayedUnstakeNear} NEAR</EstimateGetValue>
+        <EstimateGetValue>
+          {formattedReceivedDelayedUnstakeNear} NEAR
+        </EstimateGetValue>
         <UnstakeFee>Unstake fee: 0</UnstakeFee>
       </UnstakeTab>
     </UnstakeTabWrapper>
@@ -476,7 +491,7 @@ return (
         src={`${config.ownerId}/widget/LiNEAR.Modal.ConfirmInstantUnstake`}
         props={{
           config,
-          youWillReceive: receivedInstantUnstakeNear,
+          youWillReceive: formattedReceivedInstantUnstakeNear,
           onClickConfirm: onClickUnstake,
           onClickCancel: () =>
             State.update({ showConfirmInstantUnstake: false }),
@@ -488,7 +503,7 @@ return (
         src={`${config.ownerId}/widget/LiNEAR.Modal.ConfirmDelayedUnstake`}
         props={{
           config,
-          youWillReceive: receivedDelayedUnstakeNear,
+          youWillReceive: formattedReceivedDelayedUnstakeNear,
           onClickConfirm: onClickUnstake,
           onClickCancel: () =>
             State.update({ showConfirmDelayedUnstake: false }),


### PR DESCRIPTION
Fix: 

1. comma separator for received LiNEAR amount when stake
2. comma separator for received NEAR amount when instant unstake or delayed unstake
