### PR TITLE
feat: automatically register LiNEAR token to web wallet

### DIFF
--- a/src/LiNEAR.jsx
+++ b/src/LiNEAR.jsx
@@ -174,7 +174,7 @@ if (state.page === "stake") {
       {state.tabName === "stake" && (
         <Widget
           src={`${config.ownerId}/widget/LiNEAR.Stake`}
-          props={{ config, nearBalance, updateAccountInfo }}
+          props={{ config, nearBalance, linearBalance, updateAccountInfo }}
         />
       )}
       {state.tabName === "unstake" && (

--- a/src/LiNEAR/Stake.jsx
+++ b/src/LiNEAR/Stake.jsx
@@ -143,6 +143,9 @@ const onClickStake = async () => {
     },
   };
   const txs = [stake];
+  // If account has no LiNEAR, we assume she/he needs to register LiNEAR token.
+  // By adding a `ft_balance_of` function call, the NEAR indexer will automatically
+  // add LiNEAR token into caller's NEAR wallet token list.
   if (Number(linearBalance) === 0) {
     txs.push(registerFt);
   }

--- a/src/LiNEAR/Stake.jsx
+++ b/src/LiNEAR/Stake.jsx
@@ -35,6 +35,7 @@ function formatAmount(a) {
 
 /** common lib end */
 const nearBalance = props.nearBalance || "-";
+const linearBalance = props.linearBalance || "-";
 
 /** events start */
 const onChange = (e) => {
@@ -127,13 +128,26 @@ const onClickStake = async () => {
     } else setInputError("");
     return;
   }
-  Near.call(
-    config.contractId,
-    "deposit_and_stake",
-    {},
-    undefined,
-    Big(state.inputValue).mul(Big(10).pow(NEAR_DECIMALS)).toFixed(0)
-  );
+
+  const stake = {
+    contractName: config.contractId,
+    methodName: "deposit_and_stake",
+    deposit: Big(state.inputValue).mul(Big(10).pow(NEAR_DECIMALS)).toFixed(0),
+    args: {},
+  };
+  const registerFt = {
+    contractName: config.contractId,
+    methodName: "ft_balance_of",
+    args: {
+      account_id: accountId,
+    },
+  };
+  const txs = [stake];
+  if (Number(linearBalance) === 0) {
+    txs.push(registerFt);
+  }
+
+  Near.call(txs);
 
   // update account balances
   if (props.updateAccountInfo) {


### PR DESCRIPTION
By adding a `ft_balance_of` function call, the NEAR indexer will automatically add LiNEAR token into caller's NEAR wallet token list. 

<img width="588" alt="image" src="https://user-images.githubusercontent.com/95207870/236598108-5dc672d3-880e-436f-a523-75a4b9ce96ac.png">
